### PR TITLE
for 'Amazon Linux AMI' supports

### DIFF
--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -145,7 +145,7 @@ define java::oracle (
   case $::kernel {
     'Linux' : {
       case $::osfamily {
-        'RedHat' : {
+        'RedHat', 'Amazon' : {
           # Oracle Java 6 comes in a special rpmbin format
           if $version == '6' {
             $package_type = 'rpmbin'


### PR DESCRIPTION
[Amazon Linux AMI](https://aws.amazon.com/cn/amazon-linux-ami/2016.09-release-notes/) is another RedHat-like os image, openjdk-7 was shipped in that image but we  want more choices or jdk 8. i'd been tested ok for oracle jdk installation on a 't2.micro' instance.